### PR TITLE
Support secrets for gsheets creds

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,8 @@ A simple tool for tracking and visualizing support ticket queue moods.
    - Create a Google Sheet with columns: Timestamp, Mood, Note
    - Create a Google Cloud service account and download credentials.json
    - Share your sheet with the service account email
-   - Place credentials.json in the root directory
+   - Place credentials.json in the root directory **or** add the JSON to
+     your Streamlit Cloud secrets as `gcp_service_account`
    - Update `GOOGLE_SHEET_ID` in app.py with your sheet ID
 
 3. **Run the App**
@@ -35,5 +36,5 @@ A simple tool for tracking and visualizing support ticket queue moods.
 ## Project Files
 - `app.py`: Main application
 - `requirements.txt`: Dependencies
-- `credentials.json`: Google API credentials (not included in repo)
+- `credentials.json`: Google API credentials (not included in repo, optional if using Streamlit secrets)
 

--- a/app.py
+++ b/app.py
@@ -30,14 +30,24 @@ def init_gsheets():
     scope = ['https://spreadsheets.google.com/feeds',
              'https://www.googleapis.com/auth/drive']
     
-    # Check if credentials file exists
-    if not os.path.exists('credentials.json'):
-        st.error("credentials.json file not found!")
+    credentials = None
+
+    if os.path.exists('credentials.json'):
+        # Load credentials from local file if available
+        credentials = ServiceAccountCredentials.from_json_keyfile_name(
+            'credentials.json', scope)
+    elif 'gcp_service_account' in st.secrets:
+        # Use credentials provided via Streamlit secrets on Streamlit Cloud
+        credentials = ServiceAccountCredentials.from_json_keyfile_dict(
+            st.secrets['gcp_service_account'], scope)
+    else:
+        st.error(
+            "Google service account credentials not found! "
+            "Provide credentials.json or set st.secrets['gcp_service_account']."
+        )
         st.stop()
-    
+
     # Connect to Google Sheets
-    credentials = ServiceAccountCredentials.from_json_keyfile_name(
-        'credentials.json', scope)
     client = gspread.authorize(credentials)
     
     try:


### PR DESCRIPTION
## Summary
- look for Google credentials in `st.secrets['gcp_service_account']` when credentials.json is missing
- document how to provide credentials via Streamlit Cloud secrets

## Testing
- `python -m py_compile app.py`