### PR TITLE
Support secrets for gsheets creds

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,9 @@ A simple tool for tracking and visualizing support ticket queue moods.
    - Create a Google Sheet with columns: Timestamp, Mood, Note
    - Create a Google Cloud service account and download credentials.json
    - Share your sheet with the service account email
-   - Place credentials.json in the root directory
+   - Place credentials.json in the root directory **or** add its contents
+     to your Streamlit Cloud secrets as `gcp_service_account` (either as a
+     JSON string or a `[gcp_service_account]` table)
    - Update `GOOGLE_SHEET_ID` in app.py with your sheet ID
 
 3. **Run the App**
@@ -35,5 +37,5 @@ A simple tool for tracking and visualizing support ticket queue moods.
 ## Project Files
 - `app.py`: Main application
 - `requirements.txt`: Dependencies
-- `credentials.json`: Google API credentials (not included in repo)
+- `credentials.json`: Google API credentials (not included in repo, optional if using Streamlit secrets)
 


### PR DESCRIPTION
## Summary
- look for Google credentials in `st.secrets['gcp_service_account']` when credentials.json is missing
- allow secrets as a JSON string or `[gcp_service_account]` table
- document credential options in the README

## Testing
- `python -m py_compile app.py`
